### PR TITLE
Fix chat input bar disappearing in landscape mode (#5759)

### DIFF
--- a/Chatto.podspec
+++ b/Chatto.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Chatto"
-  s.version      = "4.0.3"
+  s.version      = "4.0.4"
   s.summary      = "Chat framework in Swift"
   s.description  = <<-DESC
                    Lightweight chat framework to build Chat apps

--- a/Chatto/Source/ChatController/BaseChatViewController+Scrolling.swift
+++ b/Chatto/Source/ChatController/BaseChatViewController+Scrolling.swift
@@ -199,7 +199,10 @@ extension BaseChatViewController {
         }
         let contentHeight = collectionView.collectionViewLayout.collectionViewContentSize.height
         let visibleRect = visibleRect()
-
+        // Due to floating-point precision issues near zero, subsequent calculations may produce incorrect results.
+        guard contentHeight > 0 else {
+            return true
+        }
         let distanceFromBottom = contentHeight - visibleRect.maxY
         let thresholdValue = visibleRect.height * threshold
         return distanceFromBottom <= thresholdValue

--- a/Chatto/Source/ChatController/BaseChatViewController.swift
+++ b/Chatto/Source/ChatController/BaseChatViewController.swift
@@ -326,6 +326,7 @@ open class BaseChatViewController: UIViewController,
         self.keyboardTracker?.adjustTrackingViewSizeIfNeeded()
 
         if self.isFirstLayout {
+            self.keyboardTracker?.adjustTrackingViewSize()
             self.updateQueue.start()
             self.isFirstLayout = false
         }

--- a/Chatto/Source/ChatController/Collaborators/KeyboardTracker.swift
+++ b/Chatto/Source/ChatController/Collaborators/KeyboardTracker.swift
@@ -167,13 +167,7 @@ class KeyboardTracker {
 
     func adjustTrackingViewSizeIfNeeded() {
         guard self.isTracking && self.keyboardStatus == .shown else { return }
-        self.adjustTrackingViewSize()
-    }
-
-    private func adjustTrackingViewSize() {
-        let inputContainerHeight = self.inputBarContainer.bounds.height
-        if self.keyboardTrackerView.preferredSize.height != inputContainerHeight {
-            self.keyboardTrackerView.preferredSize.height = inputContainerHeight
+        if adjustTrackingViewSize() {
             self.isPerformingForcedLayout = true
 
             // Sometimes, the autolayout system doesn't finish the layout inside of the input bar container at this point.
@@ -185,6 +179,16 @@ class KeyboardTracker {
 
             self.isPerformingForcedLayout = false
         }
+    }
+
+    @discardableResult
+    func adjustTrackingViewSize() -> Bool {
+        let inputContainerHeight = inputBarContainer.bounds.height
+        if keyboardTrackerView.preferredSize.height != inputContainerHeight {
+            keyboardTrackerView.preferredSize.height = inputContainerHeight
+            return true
+        }
+        return false
     }
 
     private func layoutInputAtBottom() {

--- a/ChattoAdditions.podspec
+++ b/ChattoAdditions.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "ChattoAdditions"
-  s.version      = "4.0.3"
+  s.version      = "4.0.4"
   s.summary      = "UI componentes for Chatto"
   s.description  = <<-DESC
                    Text and photo bubbles


### PR DESCRIPTION
https://github.com/plato-app/iPlato/issues/5759

This PR adds precalculation of the keyboard tracking view size in `viewDidLayoutSubviews`. I noticed that when the keyboard appears for the first time, the size is zero, which breaks the bottom inset calculations on iOS 26.

https://github.com/plato-app/iPlato/issues/5790

Additionally, `isCloseToBottom` was adjusted to resolve the issue of hidden first messages in empty chat